### PR TITLE
Adding Bcc support

### DIFF
--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -16,6 +16,7 @@ module Griddler
         {
           to: extract_recipients(:ToFull),
           cc: extract_recipients(:CcFull),
+          bcc: extract_recipients(:BccFull),
           from: full_email(params[:FromFull]),
           subject: params[:Subject],
           text: params[:TextBody],

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -15,6 +15,10 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
         Email: 'emily@example.com',
         Name: '',
       }],
+      BccFull: [{
+        Email: 'mary@example.com',
+        Name: 'Mary',
+      }],
       TextBody: 'hi',
     }
 
@@ -22,10 +26,11 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
     expect(Griddler::Postmark::Adapter.normalize_params(default_params)).to be_normalized_to({
       to: ['Robert Paulson <bob@example.com>'],
       cc: ['Jack <jack@example.com>'],
+      bcc: ['Mary <mary@example.com>'],
       from: 'Tyler Durden <tdurden@example.com>',
       subject: 'Reminder: First and Second Rule',
       text: /Dear bob/,
-      html: %r{<p>Dear bob</p>}
+      html: %r{<p>Dear bob</p>},
     })
   end
 
@@ -84,6 +89,10 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
       CcFull: [{
         Email: 'jack@example.com',
         Name: 'Jack'
+      }],
+      BccFull: [{
+        Email: 'mary@example.com',
+        Name: 'Mary',
       }],
       Subject: 'Reminder: First and Second Rule',
       TextBody: text_body,


### PR DESCRIPTION
This adds the `bcc` array to the normalized params.

One important thing to notice here, is that I was having problems running the tests on the master branch. I kept getting an `ArgumentError` from rspec in one of Griddler's testing matchers.

This closes #1 and it's related to thoughtbot/griddler#178.
