### PR TITLE
Handle inline attachments passed in from Postmark

### DIFF
--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/string/strip'
+require_relative 'attachment'
 
 module Griddler
   module Postmark
@@ -56,10 +57,11 @@ module Griddler
         attachments = Array(params[:Attachments])
 
         attachments.map do |attachment|
-          ActionDispatch::Http::UploadedFile.new({
+          Griddler::Postmark::Attachment.new({
             filename: attachment[:Name],
             type: attachment[:ContentType],
-            tempfile: create_tempfile(attachment)
+            tempfile: create_tempfile(attachment),
+            content_id: attachment[:ContentID]
           })
         end
       end

--- a/lib/griddler/postmark/attachment.rb
+++ b/lib/griddler/postmark/attachment.rb
@@ -1,0 +1,16 @@
+module Griddler
+  module Postmark
+    class Attachment < ActionDispatch::Http::UploadedFile
+      attr_accessor :content_id
+
+      def initialize(hash)
+        @content_id = hash[:content_id]
+        super
+      end
+
+      def inline?
+        content_id.present?
+      end
+    end
+  end
+end

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -56,6 +56,7 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
 
     expect(first.original_filename).to eq('photo1.jpg')
     expect(first.size).to eq(upload_1_params[:ContentLength])
+    expect(first.content_id).to eq(upload_1_params[:ContentID])
 
     expect(second.original_filename).to eq('photo2.jpg')
     expect(second.size).to eq(upload_2_params[:ContentLength])
@@ -153,7 +154,8 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
         Name: 'photo1.jpg',
         Content: Base64.encode64(file.read),
         ContentType: 'image/jpeg',
-        ContentLength: file.size
+        ContentLength: file.size,
+        "ContentID": "photo1.jpg@01D2DF9B.C09E7220"
       }
     end
   end

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -155,7 +155,7 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
         Content: Base64.encode64(file.read),
         ContentType: 'image/jpeg',
         ContentLength: file.size,
-        "ContentID": "photo1.jpg@01D2DF9B.C09E7220"
+        ContentID: "photo1.jpg@01D2DF9B.C09E7220"
       }
     end
   end


### PR DESCRIPTION
Postmark passes in the content id for each inbound attachment. This is handy for inlining images in the result