### PR TITLE
Add StrippedTextReply to vendor specific fields.

### DIFF
--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -25,7 +25,10 @@ module Griddler
           text: params[:TextBody],
           html: params[:HtmlBody],
           attachments: attachment_files,
-          headers: headers
+          headers: headers,
+          vendor_specific: {
+            stripped_text_reply: params[:StrippedTextReply]
+          }
         }
       end
 

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -95,6 +95,16 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
     }.to_not raise_error
   end
 
+  it 'has stripped text reply' do
+    params = default_params.merge({
+      StrippedTextReply: text_body
+    })
+
+    normalized_params = Griddler::Postmark::Adapter.normalize_params(params)
+
+    expect(normalized_params[:vendor_specific][:stripped_text_reply]).to eq(text_body)
+  end
+
   def default_params
     {
       FromFull: {


### PR DESCRIPTION
As discussed in issue #10 

Requires the use of Griddler master, it doesn't look like they have versioned a release supporting vendor specific params yet.

EDIT: I have also tested this in a working app and everything works well