### PR TITLE
Add MessageID to vendor specific params

### DIFF
--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -27,7 +27,7 @@ module Griddler
           attachments: attachment_files,
           headers: headers,
           vendor_specific: {
-            message_id: params[:MessageID]
+            message_id: params[:MessageID],
             stripped_text_reply: params[:StrippedTextReply]
           }
         }

--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -22,6 +22,7 @@ module Griddler
           reply_to: params[:ReplyTo],
           from: full_email(params[:FromFull]),
           subject: params[:Subject],
+          message_id: params[:MessageID],
           text: params[:TextBody],
           html: params[:HtmlBody],
           attachments: attachment_files,

--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -22,11 +22,13 @@ module Griddler
           reply_to: params[:ReplyTo],
           from: full_email(params[:FromFull]),
           subject: params[:Subject],
-          message_id: params[:MessageID],
           text: params[:TextBody],
           html: params[:HtmlBody],
           attachments: attachment_files,
-          headers: headers
+          headers: headers,
+          vendor_specific: {
+            message_id: params[:MessageID]
+          }
         }
       end
 

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -33,9 +33,11 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
       subject: 'Reminder: First and Second Rule',
       text: /Dear bob/,
       html: %r{<p>Dear bob</p>},
-      message_id: '73e6d360-66eb-11e1-8e72-a8904824019b',
       headers: {
         "Message-ID" => "<message-id@mail.gmail.com>"
+      },
+      vendor_specific: {
+        message_id: '73e6d360-66eb-11e1-8e72-a8904824019b'
       }
     })
   end

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -33,6 +33,7 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
       subject: 'Reminder: First and Second Rule',
       text: /Dear bob/,
       html: %r{<p>Dear bob</p>},
+      message_id: '73e6d360-66eb-11e1-8e72-a8904824019b',
       headers: {
         "Message-ID" => "<message-id@mail.gmail.com>"
       }
@@ -116,6 +117,7 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
       OriginalRecipient: "dick@example.com",
       ReplyTo: "john@example.com",
       Subject: 'Reminder: First and Second Rule',
+      MessageID: '73e6d360-66eb-11e1-8e72-a8904824019b',
       TextBody: text_body,
       HtmlBody: text_html,
       Headers: [


### PR DESCRIPTION
@r38y I did a bad merge and forgot to add a comma. Here’s the fix for it. We should add CI to this project though so this doesn’t happen again in the future.