### PR TITLE
Handle longer file names

### DIFF
--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -71,7 +71,7 @@ module Griddler
       end
 
       def create_tempfile(attachment)
-        filename = attachment[:Name].gsub(/\/|\\/, '_')
+        filename = attachment[:Name].gsub(/\/|\\/, '_')[0..150]
         tempfile = Tempfile.new(filename, Dir::tmpdir, encoding: 'ascii-8bit')
         tempfile.write(content(attachment))
         tempfile.rewind

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -95,6 +95,19 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
     }.to_not raise_error
   end
 
+  it 'can handle a really long name' do
+    params = default_params.merge({
+      Attachments: [
+        {
+          Name: ("x"*500),
+        }
+      ]
+    })
+    expect {
+      Griddler::Postmark::Adapter.normalize_params(params)
+    }.to_not raise_error
+  end
+
   it 'has stripped text reply' do
     params = default_params.merge({
       StrippedTextReply: text_body


### PR DESCRIPTION
We see errors where filenames are too long. This will truncate so they don't error.