### PR TITLE
handle attachment data in Postmark's webhook check

### DIFF
--- a/lib/griddler/postmark/adapter.rb
+++ b/lib/griddler/postmark/adapter.rb
@@ -80,11 +80,8 @@ module Griddler
       end
 
       def content(attachment)
-        if content = attachment[:Content]
-          Base64.decode64(content)
-        else
-          content
-        end
+        content = attachment[:Content] || attachment[:Data]
+        Base64.decode64(content) if content
       end
     end
   end

--- a/spec/griddler/postmark/adapter_spec.rb
+++ b/spec/griddler/postmark/adapter_spec.rb
@@ -95,6 +95,18 @@ describe Griddler::Postmark::Adapter, '.normalize_params' do
     }.to_not raise_error
   end
 
+  it 'can handle attachment content sent as Data' do
+    data_params = upload_1_params.merge(Data: upload_1_params[:Content])
+    data_params.delete(:Content)
+    params = default_params.merge({ Attachments: [data_params] })
+
+    normalized_params = Griddler::Postmark::Adapter.normalize_params(params)
+
+    first = normalized_params[:attachments].first
+    expect(first.original_filename).to eq('photo1.jpg')
+    expect(first.size).to eq(data_params[:ContentLength])
+  end
+
   it 'can handle a really long name' do
     params = default_params.merge({
       Attachments: [


### PR DESCRIPTION
despite the fact that the Postmark incoming email documentation[1] explicitly shows the base64-encoded contents of an attachment will be provided under the "Contents" key, the "Inbound Webhook" test run by pushing the "Check" button on the Inbound Stream settings page[2] instead provides the attachment contents under the "Data" key.

This change adds a test and accepts attachment content provided under the "Data" key, just in case Postmark has other places in their codebase lurking where they use that key instead.

[1]: https://postmarkapp.com/developer/user-guide/inbound/parse-an-email
[2]: https://account.postmarkapp.com/servers/:server_id/streams/inbound/settings